### PR TITLE
scurrentSpec & currentSpecs typos

### DIFF
--- a/src/scream.js
+++ b/src/scream.js
@@ -235,7 +235,7 @@ export default (config = {}) => {
         while (index--) {
             const currentSpec = specs[index];
             if (window.screen.width === currentSpec[4] &&
-              window.screen.height === scurrentSpec[5] &&
+              window.screen.height === currentSpec[5] &&
               window.devicePixelRatio === currentSpec[6]
             ) {
                 if (currentSpec[7] === "iPhone 12 mini") {

--- a/src/scream.js
+++ b/src/scream.js
@@ -242,7 +242,7 @@ export default (config = {}) => {
                     // workaround for iPhone 12 mini (hello Apple)
                     // because it has the same screen sizes and devicePixelRatio as iPhone X/XS/11 Pro
                     if (window.innerHeight >= 629 && window.innerHeight <= 743) {
-                        spec = currentSpecs;
+                        spec = currentSpec;
                         break;
                     }
                 } else {


### PR DESCRIPTION
Looks like these are just typos.
Discovered them through browserstack when trying out the module.

Seems to be working once I changed these lines.